### PR TITLE
Fix sending SessionID on authentication start

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,12 @@ Style/StringLiterals:
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/lib/ebay_request/auth.rb
+++ b/lib/ebay_request/auth.rb
@@ -14,7 +14,11 @@ class EbayRequest::Auth < EbayRequest::Trading
   end
 
   def ebay_login_url(session_id, ruparams = {})
-    params = ["SignIn", "RuName=#{config.runame}", "SessID=#{session_id}"]
+    params = [
+      "SignIn",
+      "RuName=#{CGI.escape(config.runame)}",
+      "SessID=#{CGI.escape(session_id)}",
+    ]
     ruparams = CGI.escape(ruparams.map { |k, v| "#{k}=#{v}" }.join("&"))
     params << "ruparams=#{CGI.escape(ruparams)}"
 


### PR DESCRIPTION
For new applications credentials, SessionID is issued including symbol `+`. If not escape such a session identifier it will be processed as it contains a space. eBay will not accept this SessionID on the last step.

See:

 1. http://developer.ebay.com/devzone/xml/docs/reference/ebay/getsessionid.html
 2. https://forums.developer.ebay.com/questions/10207/fetchtoken-returns-error-in-sandbox-the-secret-id.html
 3. https://stackoverflow.com/questions/38679183/invalid-secret-id-error-returned-on-fetch-token-from-ebay-api-on-production