### PR TITLE
Allow to make requests to Trading API with tokens from new REST APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EbayRequest
 
-eBay API request interface.
+eBay XML API request interface.
 
 ## Installation
 
@@ -74,6 +74,44 @@ end
 ```
 
 If you want to use just strategy you can pass all the required options as `#provider` args ([see source](https://github.com/gzigzigzeo/ebay_request/blob/master/lib/omniauth/strategies/ebay.rb#L4)).
+
+This strategy is for Auth'n'auth method only. For OAuth method see the [omniauth-ebay-oauth](https://github.com/evilmartians/omniauth-ebay-oauth) gem.
+
+
+## Working with old XML and new REST API simultaneously
+
+If you're planning to work with new eBay REST APIs, you will find that another kind of access tokens are required for working with these APIs.
+
+Tokens obtained with Auth'n'auth only usable with eBay XML API, while tokens obtained with OAuth only usable with eBay REST API.
+
+However, you can use new OAuth tokens to access old APIs by providing an access token in (not yet) documented HTTP header `X-EBAY-API-IAF-TOKEN`. This gem has builtin support for this.
+
+To use it:
+
+ 1. Replace OmniAuth strategy from this gem to the strategy from the [omniauth-ebay-oauth](https://github.com/evilmartians/omniauth-ebay-oauth) gem.
+
+    Most probably you will need to store and use both Auth'n'auth and OAuth tokens for a while to provide a smooth transition.
+
+ 2. For working with REST API and their tokens add the [ebay_api](https://github.com/nepalez/ebay_api/) gem to your application.
+
+ 3. Construct an `EbayAPI::TokenManager` instance with all OAuth tokens.
+
+    See https://github.com/nepalez/ebay_api/#working-with-access-tokens
+
+    Any object that responds to `refresh!` method and returns actual token from the `access_token` method will be fine too.
+
+ 4. Pass this token manager object in `:iaf_token_manager` option into the XML API constructor:
+
+    ```ruby
+    EbayRequest::Trading.new(
+      token: auth_n_auth_token,
+      iaf_token_manager: iaf_token_manager,
+      siteid: 0,
+    )
+    ```
+
+    You can pass both old token in `:token` option and new token manager in `:iaf_token_manager` option. Old tokens will be used if the token manager is `nil`.
+
 
 ## Development
 

--- a/lib/ebay_request/base.rb
+++ b/lib/ebay_request/base.rb
@@ -40,7 +40,7 @@ class EbayRequest::Base
   end
 
   def headers(_callname)
-    {}
+    @options[:headers] || {}
   end
 
   def payload(_callname, _request)

--- a/lib/ebay_request/response.rb
+++ b/lib/ebay_request/response.rb
@@ -13,7 +13,7 @@ class EbayRequest::Response
   end
 
   def data!
-    make_a_boom unless success?
+    raise error unless success?
     data
   end
 
@@ -34,7 +34,7 @@ class EbayRequest::Response
     fatal_errors[fatal_code] || EbayRequest::Error
   end
 
-  def make_a_boom
-    raise error_class.new(errors.values.join(", "), errors)
+  def error
+    error_class.new(errors.values.join(", "), errors)
   end
 end

--- a/lib/ebay_request/trading.rb
+++ b/lib/ebay_request/trading.rb
@@ -4,6 +4,7 @@ class EbayRequest::Trading < EbayRequest::Base
   class ItemLimitReachedError < EbayRequest::Error; end
   class DailyItemCallLimitReachedError < EbayRequest::Error; end
   class TokenValidationFailed < EbayRequest::Error; end
+  class IAFTokenExpired < TokenValidationFailed; end
   class AccountSuspended < EbayRequest::Error; end
   class ApplicationInvalid < EbayRequest::Error; end
 
@@ -18,7 +19,7 @@ class EbayRequest::Trading < EbayRequest::Base
   end
 
   def creds
-    return if options[:token].nil?
+    return if options[:token].nil? || options[:iaf_token_manager].present?
     %(<RequesterCredentials>\
 <eBayAuthToken>#{options[:token]}</eBayAuthToken>\
 </RequesterCredentials>)
@@ -29,15 +30,20 @@ class EbayRequest::Trading < EbayRequest::Base
   end
 
   def headers(callname)
-    super.merge(
+    authorized_headers = {
       "Content-Type" => "text/xml",
       "X-EBAY-API-APP-NAME" => EbayRequest.config.appid,
       "X-EBAY-API-DEV-NAME" => EbayRequest.config.devid,
       "X-EBAY-API-CERT-NAME" => EbayRequest.config.certid,
       "X-EBAY-API-COMPATIBILITY-LEVEL" => EbayRequest.config.version.to_s,
       "X-EBAY-API-CALL-NAME" => callname,
-      "X-EBAY-API-SITEID" => siteid.to_s
-    )
+      "X-EBAY-API-SITEID" => siteid.to_s,
+    }
+    if options[:iaf_token_manager]
+      authorized_headers["X-EBAY-API-IAF-TOKEN"] =
+          options[:iaf_token_manager].access_token
+    end
+    super.merge(authorized_headers)
   end
 
   def errors_for(r)
@@ -45,6 +51,19 @@ class EbayRequest::Trading < EbayRequest::Base
       .flatten
       .compact
       .map { |e| [e["SeverityCode"], e["ErrorCode"], e["LongMessage"]] }
+  end
+
+  def request(*)
+    retried ||= false
+    super.tap do |response|
+      next if retried || options[:iaf_token_manager].nil?
+      next if response.success? || response.error_class > IAFTokenExpired
+      raise response.error
+    end
+  rescue IAFTokenExpired
+    options[:iaf_token_manager].refresh!
+    retried = true
+    retry
   end
 
   # http://developer.ebay.com/devzone/xml/docs/reference/ebay/errors/errormessages.htm
@@ -56,6 +75,8 @@ class EbayRequest::Trading < EbayRequest::Base
     931        => TokenValidationFailed,
     17_470     => TokenValidationFailed,
     16_110     => TokenValidationFailed,
+    21_916_984 => TokenValidationFailed,
+    21_917_053 => IAFTokenExpired,
     841        => AccountSuspended,
     127        => ApplicationInvalid
   }.freeze

--- a/spec/ebay_request/trading_spec.rb
+++ b/spec/ebay_request/trading_spec.rb
@@ -54,6 +54,15 @@ xmlns="urn:ebay:apis:eBLBaseComponents">\
 </Errors></AddItemResponse>)
   end
 
+  let(:response_with_expired_iaf_token_error) do
+    %(<AddItemResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+<Timestamp>2017-10-10T11:07:21.220Z</Timestamp><Ack>Failure</Ack><Errors>
+<ShortMessage>Expired IAF token.</ShortMessage>
+<LongMessage>IAF token supplied is expired. </LongMessage>
+<SeverityCode>Error</SeverityCode><ErrorCode>21917053</ErrorCode>
+</Errors></AddItemResponse>)
+  end
+
   let(:response_with_warning) do
     %(<AddItemResponse xmlns="urn:ebay:apis:eBLBaseComponents">
 <Timestamp>2016-04-18T12:12:26.600Z</Timestamp><Ack>Warning</Ack><Errors>
@@ -186,5 +195,31 @@ xmlns="urn:ebay:apis:eBLBaseComponents">\
       EbayRequest::Trading::IllegalItemStateError,
       "This listing may be identical to test item"
     )
+  end
+
+  context("using IAF token") do
+    subject { described_class.new(iaf_token_manager: token_manager) }
+
+    let(:token_manager) do
+      double("IAF token manager", refresh!: nil, access_token: "some_token")
+    end
+
+    let!(:api) do
+      stub_request(:post, "https://api.sandbox.ebay.com/ws/api.dll")
+        .with(body: failing_request, headers: headers)
+        .to_return(status: 200, body: response_with_expired_iaf_token_error)
+        .to_return(status: 200, body: successful_response)
+    end
+
+    it "#response with iaf token expired error tries to refresh token" do
+      response = subject.response("AddItem", Item: { Title: "i" })
+
+      expect(token_manager).to have_received(:refresh!)
+      expect(response).to be_success
+      expect(response.errors).to eq({})
+      expect(response.warnings).to eq({})
+      expect(response.data!).to be
+      expect(api).to have_been_requested.twice
+    end
   end
 end


### PR DESCRIPTION
The version of #12 with all stuff which is not directly related to the working with eBay XML APIs extracted to separate gems: [ebay_api](https://github.com/nepalez/ebay_api/) and [omniauth-ebay-oauth](https://github.com/evilmartians/omniauth-ebay-oauth)

Added manual and explanation into the README