### PR TITLE
Add minimal fixed price for ebay.com.au

### DIFF
--- a/config/sites.yml
+++ b/config/sites.yml
@@ -60,7 +60,7 @@
   free_pictures: 12
   subtitle_fee: 2
   gtc_available: true
-  min_fixed_price: # no limit at https://pages.ebay.com.au/help/sell/fixed-price.html
+  min_fixed_price: 1.00 # found experimentally, help page was moved to unknown place
 
 - globalid: EBAY-CH
   id: 193


### PR DESCRIPTION
Thanks to @simple-elf for thorough checking all sites we're using, so we've found one more site that seems to limit minimal fixed price (this one is last, I promise).

Page https://pages.ebay.com.au/help/sell/fixed-price.html is now redirecting to the non-related page about auction's reserved price. We are observing errors about the wrong price if it is set less than 1 AUD for fixed-price items.