### PR TITLE
Fix eBay sites metadata for eBay Motors, eBay Belgium (Dutch)

### DIFF
--- a/config/sites.yml
+++ b/config/sites.yml
@@ -244,7 +244,7 @@
 
 - globalid: EBAY-MOTOR
   id: 100
-  name: US Motors
+  name: eBayMotors
   code: MOTOR
   currency: USD
   language: en

--- a/config/sites.yml
+++ b/config/sites.yml
@@ -156,6 +156,17 @@
   country: BE
   min_fixed_price: 1.00 # https://pages.befr.ebay.be/help/sell/fixed-price.html
 
+- globalid: EBAY-NLBE
+  id: 123
+  name: Belgium_Dutch
+  code: BENL
+  currency: EUR
+  language: de
+  domain: ebay.be
+  metric: metric
+  country: BE
+  min_fixed_price: # no limit at https://pages.benl.ebay.be/help/sell/fixed-price.html
+
 - globalid: EBAY-FRCA
   id: 210
   name: CanadaFrench
@@ -275,17 +286,6 @@
   metric: metric
   country: NL
   min_fixed_price: # no limit at https://pages.ebay.nl/help/sell/fixed-price.html
-
-- globalid: EBAY-NLBE
-  id: 123
-  name: Belgium_Dutch
-  code: BENL
-  currency: EUR
-  language: de
-  domain: ebay.be
-  metric: metric
-  country: BE
-  min_fixed_price: # no limit at https://pages.benl.ebay.be/help/sell/fixed-price.html
 
 - globalid: EBAY-PH
   id: 211

--- a/config/sites.yml
+++ b/config/sites.yml
@@ -282,7 +282,7 @@
   code: BENL
   currency: EUR
   language: de
-  domain: ebay.nl
+  domain: ebay.be
   metric: metric
   country: BE
   min_fixed_price: # no limit at https://pages.benl.ebay.be/help/sell/fixed-price.html


### PR DESCRIPTION
In data returned by `GetItem` call for listing placed on the eBay Motors pseudo site `eBayMotors` name is being used inside the tag [Item.Site](https://developer.ebay.com/devzone/xml/docs/reference/ebay/getitem.html#Response.Item.Site).

See https://developer.ebay.com/devzone/xml/docs/reference/ebay/types/SiteCodeType.html for reference

A wrong domain is specified for Belgium Dutch eBay site (ebay.nl instead of ebay.be)