### PR TITLE
Update eBay sites metadata

### DIFF
--- a/config/sites.yml
+++ b/config/sites.yml
@@ -124,7 +124,7 @@
   max_insertion_fee: 0.35
   free_pictures: 12
   subtitle_fee: 0.41
-  gtc_available: false
+  gtc_available: true
   min_fixed_price: 0.99 # https://pages.ebay.es/help/sell/fixed-price.html
 
 - globalid: EBAY-FR
@@ -142,7 +142,7 @@
   free_pictures: 1
   picture_fee: 0.13
   subtitle_fee: 0.42
-  gtc_available: false
+  gtc_available: true
   min_fixed_price: 1.00 # https://pages.ebay.fr/help/sell/fixed-price.html
 
 - globalid: EBAY-FRBE
@@ -250,7 +250,7 @@
   free_pictures: 1
   picture_fee: 0.12
   subtitle_fee: 0.41
-  gtc_available: false
+  gtc_available: true
   min_fixed_price: 1.00 # https://pages.ebay.it/help/sell/fixed-price.html
 
 - globalid: EBAY-MOTOR

--- a/config/sites.yml
+++ b/config/sites.yml
@@ -259,7 +259,7 @@
   code: MOTOR
   currency: USD
   language: en
-  domain: ebay.com/motors
+  domain: ebay.com
   metric: imperial
   country: US
   shipping_zones: [US, Americas, NorthAmerica]

--- a/spec/ebay_request/config_spec.rb
+++ b/spec/ebay_request/config_spec.rb
@@ -56,7 +56,7 @@ describe EbayRequest::Config do
     end
 
     it "returns gtc_available for 71" do
-      expect(described_class.sites_by_id[71]).not_to be_gtc_available
+      expect(described_class.sites_by_id[71]).to be_gtc_available
     end
 
     it "raises when gtc availability asked for 207" do


### PR DESCRIPTION
 1. Mark FRITES sites as supporting GTC
    
    GTC is supported at least starting from December 2018
    
    GTC duration is acceptable by every category on every eBay site with exceptions of:
     - US auto/motorcycles
     - several (~270) categories on the Polish site

 2. Set domain for eBay Motors to ebay.com as it's now part of eBay US