### PR TITLE
Add EbayRequest::Error::BlankResponse specific exception

### DIFF
--- a/lib/ebay_request/base.rb
+++ b/lib/ebay_request/base.rb
@@ -60,7 +60,10 @@ class EbayRequest::Base
   def process(response, callname)
     data = response["#{callname}Response"]
 
-    raise EbayRequest::Error, "#{callname} response is blank" if data.nil?
+    if data.nil?
+      raise EbayRequest::Error::BlankResponse, "#{callname} response is blank"
+    end
+
     EbayRequest::Response.new(
       callname, data, errors_for(data), self.class::FATAL_ERRORS
     )

--- a/lib/ebay_request/error.rb
+++ b/lib/ebay_request/error.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EbayRequest::Error < StandardError
+  class BlankResponse < self; end
+
   def initialize(msg = "EbayRequest error", errors: [], warnings: [])
     super(msg)
     @errors   = errors


### PR DESCRIPTION
I added this subclass to make it easier for the application to retry this error (because it is mostly recoverable)