### PR TITLE
Fix error code coercion

### DIFF
--- a/ebay_request.gemspec
+++ b/ebay_request.gemspec
@@ -31,7 +31,7 @@ gem pushes."
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "> 1.11"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/ebay_request/error_item.rb
+++ b/lib/ebay_request/error_item.rb
@@ -4,10 +4,10 @@
 class EbayRequest::ErrorItem
   extend Dry::Initializer
 
-  option :code, method(:Integer), comment: "Numeric error identifier"
-  option :message, proc(&:to_s), comment: "Human-readable error description"
+  option :code,     proc(&:to_i), comment: "Numeric error identifier"
+  option :message,  proc(&:to_s), comment: "Human-readable error description"
   option :severity, proc(&:to_s), comment: "Either +Error+ of +Warning+"
-  option :params, proc(&:to_h), default: -> { {} }, comment: "Variable parts of message"
+  option :params,   proc(&:to_h), default: -> { {} }, comment: "Variable parts of message"
 
   def self.new(source)
     source = source.to_h.each_with_object({}) { |(k, v), obj| obj[k.to_sym] = v }


### PR DESCRIPTION
...because `proc(&:to_i)` is safer than `method(:Integer)` when dealing with `nil`:

```ruby
nil.to_i # => 0
Integer(nil) # => TypeError: can't convert nil into Integer
```